### PR TITLE
Fix: release-please PR eternally expected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ clean:
 
 test: lint
 	go test ./src -v -count=1 -timeout 0
+


### PR DESCRIPTION
This is an empty commit to trigger the release-please PR again without eternally expected checks.

Leuk!