### PR TITLE
Fix: prevent eternal "expected" tests with reused action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,6 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: google-github-actions/release-please-action@v3
-        with:
-          release-type: simple
-          # if we are not at v1.0.0 yet, breaking changes do not need to add a new major version
-          bump-minor-pre-major: true
-          pull-request-title-pattern: "chore: ${scope} release${component} ${version}"
-
+    uses: VU-ASE/actions/.github/workflows/release.yaml@main
+    secrets:
+      release_please_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
This repository was not using our shared release actions yet (https://github.com/VU-ASE/actions/blob/main/.github/workflows/release.yaml). Additionally, it was using the default GITHUB_TOKEN instead of a custom PAT, which does not cascade workflow runs....  (See https://github.com/orgs/community/discussions/54574#discussioncomment-10119733)