### PR TITLE
Added unit tests for undefined behavior on setter methods

### DIFF
--- a/src/configuration_test.go
+++ b/src/configuration_test.go
@@ -2,10 +2,10 @@ package roverlib
 
 import (
 	//"fmt"
+
+	"reflect"
 	"sync"
 	"testing"
-	"reflect"
-
 	//roverlib "github.com/VU-ASE/roverlib-go/src"
 )
 
@@ -19,8 +19,24 @@ func sampleService() Service {
 	valConfig2 := "auto"
 	return Service{
 		Configuration: []Configuration{
-			{Name: &name1, Type: &num,   Tunable: &tTrue,  Value: &Value{Double: &valConfig1}},
-			{Name: &name2, Type: &str,   Tunable: &tFalse, Value: &Value{String: &valConfig2}},
+			{Name: &name1, Type: &num, Tunable: &tTrue, Value: &Value{Double: &valConfig1}},
+			{Name: &name2, Type: &str, Tunable: &tFalse, Value: &Value{String: &valConfig2}},
+		},
+	}
+}
+
+// helper: tunable service that contains different types of configuration options
+func tunableService() Service {
+	num := Number
+	str := String
+	tTrue := true
+	name1, name2 := "float1", "string1"
+	valConfig1 := 3.14
+	valConfig2 := "auto"
+	return Service{
+		Configuration: []Configuration{
+			{Name: &name1, Type: &num, Tunable: &tTrue, Value: &Value{Double: &valConfig1}},
+			{Name: &name2, Type: &str, Tunable: &tTrue, Value: &Value{String: &valConfig2}},
 		},
 	}
 }
@@ -28,7 +44,7 @@ func sampleService() Service {
 // Checks that NewServiceConfiguration correctly builds the maps for float, string, and tunable options
 func TestNewServiceConfigurationBuildsMaps(t *testing.T) {
 	cfg := NewServiceConfiguration(sampleService())
-	wantFloats  := map[string]float64{"config1": 3.14}
+	wantFloats := map[string]float64{"config1": 3.14}
 	wantStrings := map[string]string{"config2": "auto"}
 	wantTunable := map[string]bool{"config1": true, "config2": false}
 
@@ -95,11 +111,11 @@ func TestGetStringSafeConcurrent(t *testing.T) {
 // Tests setting a float configuration on both the tunable and non-tunable options
 func TestSetFloatTunable(t *testing.T) {
 	cfg := NewServiceConfiguration(sampleService())
-	cfg.setFloat("config1", 6.28)    // tunable → should update
+	cfg.setFloat("config1", 6.28) // tunable → should update
 	if v, _ := cfg.GetFloat("config1"); v != 6.28 {
 		t.Fatalf("pi not updated: got %v", v)
 	}
-	cfg.setFloat("config2", 1.23)  // not tunable → ignore
+	cfg.setFloat("config2", 1.23) // not tunable → ignore
 	if _, err := cfg.GetFloat("config2"); err == nil {
 		t.Fatalf("string option should not be in float map")
 	}
@@ -114,5 +130,37 @@ func TestGettersMissingKey(t *testing.T) {
 	}
 	if _, err := cfg.GetString("missing"); err == nil {
 		t.Fatalf("expected error for missing string key")
+	}
+}
+
+// Test that when SetFloat is called with a string value (or vice versa),
+// it does not cause undefined behavior (see https://linear.app/vu-ase/issue/ASE-115/roverlib-go-configurationgo-set-functions-can-cause-undefined)
+func TestSettersUndefinedBehavior(t *testing.T) {
+	cfg := NewServiceConfiguration(tunableService())
+
+	// Float testing
+	newVal := 2.71
+	cfg.setFloat("float1", newVal)
+	// Try to override with a string value (should not be possible)
+	cfg.setString("float1", "not a float")
+	val, err := cfg.GetFloat("float1")
+	if err != nil {
+		t.Fatalf("GetFloat after setString returned error: %v", err)
+	}
+	if (val - newVal) > 1e-6 {
+		t.Fatalf("GetFloat after setString returned unexpected value: got %v, want %v", val, newVal)
+	}
+
+	// String testing
+	newStr := "updated string"
+	cfg.setString("string1", newStr)
+	// Try to override with a float value (should not be possible)
+	cfg.setFloat("string1", 42.0)
+	valStr, err := cfg.GetString("string1")
+	if err != nil {
+		t.Fatalf("GetString after setFloat returned error: %v", err)
+	}
+	if valStr != newStr {
+		t.Fatalf("GetString after setFloat returned unexpected value: got %q, want %q", valStr, newStr)
 	}
 }

--- a/src/index.go
+++ b/src/index.go
@@ -26,9 +26,17 @@ func setupLogging(debug bool, outputPath string, service Service) {
 	// Set up custom caller prefix
 	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
 		path := strings.Split(file, "/")
+
+		// Sometimes during unit tests, the service name is not set,
+		// causing a segfault. This is a workaround for that
+		name := "unknown"
+		if service.Name != nil {
+			name = *service.Name
+		}
+
 		// only take the last three elements of the path
 		filepath := strings.Join(path[len(path)-3:], "/")
-		return fmt.Sprintf("[%s] %s:%d", *service.Name, filepath, line)
+		return fmt.Sprintf("[%s] %s:%d", name, filepath, line)
 	}
 	outputWriter := zerolog.ConsoleWriter{Out: os.Stderr}
 	log.Logger = log.Output(outputWriter).With().Caller().Logger()


### PR DESCRIPTION
As described by https://linear.app/vu-ase/issue/ASE-115/roverlib-go-configurationgo-set-functions-can-cause-undefined.

This also includes a small fix for the logger setup, which broke (sometimes) during unit tests because of a segfault.

@dari101 the testing setup works nicely!